### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
     "name": "grunt-global-wrap",
-    "keywords": ["browserify", "commonjs", "modules", "global", "browsers", "build", "gruntplugin"],
+    "keywords": [
+        "browserify",
+        "commonjs",
+        "modules",
+        "global",
+        "browsers",
+        "build",
+        "gruntplugin"
+    ],
     "description": "Grunt task to expose your CommonJS-based libraries as a global.",
     "version": "1.1.0",
     "author": "Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com)",
@@ -15,7 +23,7 @@
         "lint": "jshint tasks"
     },
     "peerDependencies": {
-        "grunt": "~0.4.0"
+        "grunt": ">=0.4.0"
     },
     "dependencies": {
         "global-wrap": ">=1.2.0 <2"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
